### PR TITLE
Add RunWithExecutionHandler API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.bin
+.kube

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ deploy: test-cluster
 	kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
 
 test:
-	kubectl exec -it $(POD_NAME) -- go test -v ./
+	kubectl exec -it $(POD_NAME) -- go test -v ./ -count=1

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ test-cluster: $(KIND)
 	fi ;\
 	}
 
+delete-cluster: $(KIND)
+	$(KIND) delete clusters $(CLUSTER_NAME)
+
 build-image:
 	docker build -t kubejob:latest .
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+SHELL := /bin/bash
+
+BIN := $(CURDIR)/.bin
+PATH := $(abspath $(BIN)):$(PATH)
+
+UNAME_OS := $(shell uname -s)
+
+$(BIN):
+	@mkdir -p $(BIN)
+
+KIND := $(BIN)/kind
+KIND_VERSION := v0.8.1
+$(KIND): | $(BIN)
+	@curl -sSLo $(KIND) "https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(UNAME_OS)-amd64"
+	@chmod +x $(KIND)
+
+CLUSTER_NAME ?= kubejob-cluster
+KUBECONFIG ?= $(CURDIR)/.kube/config
+export KUBECONFIG
+
+POD_NAME := $(shell KUBECONFIG=$(KUBECONFIG) kubectl get pod | grep Running | grep kubejob-deployment | awk '{print $$1}' )
+
+test-cluster: $(KIND)
+	@{ \
+	set -e ;\
+	if [ "$$(kind get clusters --quiet | grep $(CLUSTER_NAME))" = "" ]; then \
+		$(KIND) create cluster --name $(CLUSTER_NAME) --config testdata/config/cluster.yaml ;\
+	fi ;\
+	}
+
+build-image:
+	docker build -t kubejob:latest .
+
+delete-image:
+	docker image rm -f kubejob:latest
+
+upload-image: build-image
+	@$(KIND) load --name $(TEST_CLUSTER_NAME) docker-image kubejob:latest
+
+deploy: test-cluster
+	kubectl apply -f testdata/config/manifest.yaml
+	kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
+
+test:
+	kubectl exec -it $(POD_NAME) -- go test -v ./

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/kubejob_test.go
+++ b/kubejob_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/goccy/kubejob"
+	"golang.org/x/xerrors"
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
@@ -47,30 +48,82 @@ func Test_Run(t *testing.T) {
 }
 
 func Test_RunnerWithExecutionHandler(t *testing.T) {
-	job, err := kubejob.NewJobBuilder(cfg, "default").BuildWithJob(&batchv1.Job{
-		Spec: batchv1.JobSpec{
-			Template: apiv1.PodTemplateSpec{
-				Spec: apiv1.PodSpec{
-					Containers: []apiv1.Container{
-						{
-							Name:    "test",
-							Image:   "golang:1.15",
-							Command: []string{"echo", "foo"},
+	t.Run("success", func(t *testing.T) {
+		job, err := kubejob.NewJobBuilder(cfg, "default").BuildWithJob(&batchv1.Job{
+			Spec: batchv1.JobSpec{
+				Template: apiv1.PodTemplateSpec{
+					Spec: apiv1.PodSpec{
+						Containers: []apiv1.Container{
+							{
+								Name:    "test",
+								Image:   "golang:1.15",
+								Command: []string{"echo", "foo"},
+							},
 						},
 					},
 				},
 			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("failed to build job: %+v", err)
-	}
-	if err := job.RunWithExecutionHandler(context.Background(), func(executors []*kubejob.JobExecutor) error {
-		for _, exec := range executors {
-			exec.Exec()
+		})
+		if err != nil {
+			t.Fatalf("failed to build job: %+v", err)
 		}
-		return nil
-	}); err != nil {
-		t.Fatalf("failed to run: %+v", err)
-	}
+		if err := job.RunWithExecutionHandler(context.Background(), func(executors []*kubejob.JobExecutor) error {
+			for _, exec := range executors {
+				out, err := exec.Exec()
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				if string(out) != "foo\n" {
+					t.Fatalf("cannot get output %q", string(out))
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("failed to run: %+v", err)
+		}
+	})
+	t.Run("failure", func(t *testing.T) {
+		job, err := kubejob.NewJobBuilder(cfg, "default").BuildWithJob(&batchv1.Job{
+			Spec: batchv1.JobSpec{
+				Template: apiv1.PodTemplateSpec{
+					Spec: apiv1.PodSpec{
+						Containers: []apiv1.Container{
+							{
+								Name:    "test",
+								Image:   "golang:1.15",
+								Command: []string{"cat", "fuga"},
+							},
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed to build job: %+v", err)
+		}
+		if err := job.RunWithExecutionHandler(context.Background(), func(executors []*kubejob.JobExecutor) error {
+			for _, exec := range executors {
+				out, err := exec.Exec()
+				if err == nil {
+					t.Fatal("expect error")
+				}
+				var failedJob *kubejob.FailedJob
+				if xerrors.As(err, &failedJob) {
+					for _, container := range failedJob.FailedContainers() {
+						if container.Name != "test" {
+							t.Fatalf("cannot get valid container: %s", container.Name)
+						}
+					}
+				} else {
+					t.Fatal("cannot get FailedJob")
+				}
+				if string(out) != "cat: fuga: No such file or directory\n" {
+					t.Fatalf("cannot get output %q", string(out))
+				}
+			}
+			return nil
+		}); err == nil {
+			t.Fatal("expect error")
+		}
+	})
 }

--- a/kubejob_test.go
+++ b/kubejob_test.go
@@ -1,0 +1,54 @@
+package kubejob_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/goccy/kubejob"
+	batchv1 "k8s.io/api/batch/v1"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	cfg       *rest.Config
+	clientset *kubernetes.Clientset
+)
+
+func init() {
+	c, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err)
+	}
+	set, err := kubernetes.NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	cfg = c
+	clientset = set
+}
+
+func Test_Run(t *testing.T) {
+	job, err := kubejob.NewJobBuilder(clientset, "default").BuildWithJob(&batchv1.Job{
+		Spec: batchv1.JobSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:    "test",
+							Image:   "golang:1.15",
+							Command: []string{"echo", "hello"},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to build job: %+v", err)
+	}
+	if err := job.Run(context.Background()); err != nil {
+		t.Fatalf("failed to run: %+v", err)
+	}
+}

--- a/kubejob_test.go
+++ b/kubejob_test.go
@@ -7,13 +7,11 @@ import (
 	"github.com/goccy/kubejob"
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
 var (
-	cfg       *rest.Config
-	clientset *kubernetes.Clientset
+	cfg *rest.Config
 )
 
 func init() {
@@ -21,16 +19,11 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	set, err := kubernetes.NewForConfig(c)
-	if err != nil {
-		panic(err)
-	}
 	cfg = c
-	clientset = set
 }
 
 func Test_Run(t *testing.T) {
-	job, err := kubejob.NewJobBuilder(clientset, "default").BuildWithJob(&batchv1.Job{
+	job, err := kubejob.NewJobBuilder(cfg, "default").BuildWithJob(&batchv1.Job{
 		Spec: batchv1.JobSpec{
 			Template: apiv1.PodTemplateSpec{
 				Spec: apiv1.PodSpec{
@@ -49,6 +42,35 @@ func Test_Run(t *testing.T) {
 		t.Fatalf("failed to build job: %+v", err)
 	}
 	if err := job.Run(context.Background()); err != nil {
+		t.Fatalf("failed to run: %+v", err)
+	}
+}
+
+func Test_RunnerWithExecutionHandler(t *testing.T) {
+	job, err := kubejob.NewJobBuilder(cfg, "default").BuildWithJob(&batchv1.Job{
+		Spec: batchv1.JobSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:    "test",
+							Image:   "golang:1.15",
+							Command: []string{"echo", "foo"},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to build job: %+v", err)
+	}
+	if err := job.RunWithExecutionHandler(context.Background(), func(executors []*kubejob.JobExecutor) error {
+		for _, exec := range executors {
+			exec.Exec()
+		}
+		return nil
+	}); err != nil {
 		t.Fatalf("failed to run: %+v", err)
 	}
 }

--- a/testdata/config/cluster.yaml
+++ b/testdata/config/cluster.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+  extraMounts:
+  - hostPath: .
+    containerPath: /home/kubejob
+networking:
+  disableDefaultCNI: true # disable kindnet
+  podSubnet: 192.168.0.0/16 # set to Calico's default subnet

--- a/testdata/config/manifest.yaml
+++ b/testdata/config/manifest.yaml
@@ -26,6 +26,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     verbs:
       - get

--- a/testdata/config/manifest.yaml
+++ b/testdata/config/manifest.yaml
@@ -1,0 +1,78 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kubejob
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubejob
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubejob
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubejob
+subjects:
+- kind: ServiceAccount
+  name: kubejob
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: kubejob-deployment
+  labels:
+    app: nginx
+spec:
+  selector:
+    matchLabels:
+      app: kubejob
+  template:
+    metadata:
+      name: kubejob
+      labels:
+        app: kubejob
+    spec:
+      serviceAccountName: kubejob
+      containers:
+        - name: kubejob
+          image: golang:1.15
+          workingDir: /go/src/kubejob
+          command:
+            - tail
+          args:
+            - -f
+            - /dev/null
+          volumeMounts:
+            - name: workdir
+              mountPath: /go/src/kubejob
+      volumes:
+        - name: workdir
+          hostPath:
+            path: /home/kubejob
+            type: Directory


### PR DESCRIPTION
Add feature to manually execute job commands for each container .

```go
if err := job.RunWithExecutionHandler(context.Background(), func(executors []*kubejob.JobExecutor) error {
  for _, exec := range executors {
    out, err := exec.Exec()
    if err != nil {
      panic(err)
    }
    fmt.Println(string(out))
  }
  return nil
}); err != nil {
  panic(err)
}
```