### PR TITLE
Fix cleanup process and command buffering

### DIFF
--- a/kubejob_test.go
+++ b/kubejob_test.go
@@ -47,6 +47,31 @@ func Test_Run(t *testing.T) {
 	}
 }
 
+func Test_RunWithVerboseLog(t *testing.T) {
+	job, err := kubejob.NewJobBuilder(cfg, "default").BuildWithJob(&batchv1.Job{
+		Spec: batchv1.JobSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:    "test",
+							Image:   "golang:1.15",
+							Command: []string{"echo", "hello"},
+						},
+					},
+				},
+			},
+		},
+	})
+	job.SetVerboseLog(true)
+	if err != nil {
+		t.Fatalf("failed to build job: %+v", err)
+	}
+	if err := job.Run(context.Background()); err != nil {
+		t.Fatalf("failed to run: %+v", err)
+	}
+}
+
 func Test_RunnerWithExecutionHandler(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		job, err := kubejob.NewJobBuilder(cfg, "default").BuildWithJob(&batchv1.Job{

--- a/testdata/config/manifest.yaml
+++ b/testdata/config/manifest.yaml
@@ -19,6 +19,14 @@ rules:
       - ""
     resources:
       - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
       - pods/log
     verbs:
       - get


### PR DESCRIPTION
### Fix cleanup process

`kubejob` run `list` and `delete` in cleanup phase for `pods` resource .
But did not specified these permissions to `manifest.yaml` .

Also, since currently ignored returned `error` by `podClient.List` ( https://github.com/goccy/kubejob/compare/feature/fix-cleanup?expand=1#diff-d25200def3804ad5276ed9f6b2e57f0681afe30e7b1929ccd2dacda060b920c2L435 ), we don't notice this bugs ....

In cleanup process, we should delete immediately job and pod resources .
So, we specified zero value to `GracePeriodSeconds` option to delete them .

### Fix command bufferring 

Currently, use `bytes.Buffer` with `sync.Mutex` for buffering command log .
But this idea is not good, `io.Pipe` solution better than that implementation .

### Add Verbose Logging

Added verbose logger to notice bugs of cleanup process instantly .
