### PR TITLE
Add test case for handling of cancel

### DIFF
--- a/job.go
+++ b/job.go
@@ -575,7 +575,7 @@ func (j *Job) watchLoop(ctx context.Context, watcher watch.Interface) (e error) 
 		var phase core.PodPhase
 		for event := range watcher.ResultChan() {
 			pod = event.Object.(*core.Pod)
-			if ctx.Err() != nil {
+			if ctx.Err() != nil && pod.Status.Phase == core.PodRunning {
 				return nil
 			}
 			if pod.Status.Phase == phase {

--- a/kubejob_test.go
+++ b/kubejob_test.go
@@ -470,8 +470,7 @@ func Test_RunnerWithCancel(t *testing.T) {
 	cancel()
 
 	if err := job.RunWithExecutionHandler(ctx, func(executors []*kubejob.JobExecutor) error {
-		t.Fatal("shouldn't call handler")
-		return nil
+		return fmt.Errorf("shouldn't call handler")
 	}); err != nil {
 		t.Fatalf("failed to run: %+v", err)
 	}

--- a/kubejob_test.go
+++ b/kubejob_test.go
@@ -2,6 +2,7 @@ package kubejob_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/goccy/kubejob"


### PR DESCRIPTION
If call `cancel()` func of `context.WithCancel()` , `ctx.Err()` returns not nil.
Then, `kubejob` wait `core.PodRunning` status and stop current running process .