### PR TITLE
Fix command for JobExecutor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,16 @@ test:
 		sleep 1; \
 	done; \
 	}
+
+test-run:
+	{ \
+	set -e ;\
+	while true; do \
+		POD_NAME=$$(KUBECONFIG=$(KUBECONFIG) kubectl get pod | grep Running | grep kubejob-deployment | awk '{print $$1}'); \
+		if [ "$$POD_NAME" != "" ]; then \
+			kubectl exec -it $$POD_NAME -- go test -v -coverprofile=coverage.out ./ -count=1 -run $(TEST); \
+			exit $$?; \
+		fi; \
+		sleep 1; \
+	done; \
+	}

--- a/job.go
+++ b/job.go
@@ -267,9 +267,11 @@ type JobExecutor struct {
 // there is no quote for `x; y; z`, so if you wrap the command with `sh -c`, it will occur unexpectedly behavior.
 // To prevent that, explicitly add quote to that command.
 func (e *JobExecutor) normalizeCmd(cmd []string) []string {
+	const whiteSpace = " "
 	normalizedCmd := make([]string, 0, len(cmd))
 	for _, c := range cmd {
-		if strings.Contains(c, " ") {
+		c = strings.Trim(c, whiteSpace)
+		if strings.Contains(c, whiteSpace) {
 			normalizedCmd = append(normalizedCmd, strconv.Quote(c))
 		} else {
 			normalizedCmd = append(normalizedCmd, c)

--- a/job.go
+++ b/job.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -262,6 +263,21 @@ type JobExecutor struct {
 	err         error
 }
 
+// If a command like `sh -c "x; y; z" is passed as a cmd,
+// there is no quote for `x; y; z`, so if you wrap the command with `sh -c`, it will occur unexpectedly behavior.
+// To prevent that, explicitly add quote to that command.
+func (e *JobExecutor) normalizeCmd(cmd []string) []string {
+	normalizedCmd := make([]string, 0, len(cmd))
+	for _, c := range cmd {
+		if strings.Contains(c, " ") {
+			normalizedCmd = append(normalizedCmd, strconv.Quote(c))
+		} else {
+			normalizedCmd = append(normalizedCmd, c)
+		}
+	}
+	return normalizedCmd
+}
+
 func (e *JobExecutor) exec(cmd []string) ([]byte, error) {
 	pod := e.Pod
 	req := e.job.restClient.Post().
@@ -271,7 +287,7 @@ func (e *JobExecutor) exec(cmd []string) ([]byte, error) {
 		SubResource("exec").
 		VersionedParams(&core.PodExecOptions{
 			Container: e.Container.Name,
-			Command:   []string{"sh", "-c", strings.Join(cmd, " ")},
+			Command:   []string{"sh", "-c", strings.Join(e.normalizeCmd(cmd), " ")},
 			Stdin:     false,
 			Stdout:    true,
 			Stderr:    true,

--- a/kubejob_test.go
+++ b/kubejob_test.go
@@ -175,7 +175,8 @@ func Test_RunnerWithExecutionHandler(t *testing.T) {
 							{
 								Name:    "test",
 								Image:   "golang:1.15",
-								Command: []string{"echo", "$TEST"},
+								Command: []string{"sh", "-c"},
+								Args:    []string{"set -eu; echo $TEST"},
 								Env: []apiv1.EnvVar{
 									{
 										Name:  "TEST",


### PR DESCRIPTION
In JobExecutor, fix a bug that causes unexpected behavior when given a command like `sh -c "x; y; z"`
