### PR TITLE
[Breaking Changes] Change Job Deletion Spec

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -110,14 +110,12 @@ func (b *JobBuilder) BuildWithJob(jobSpec *batchv1.Job) (*Job, error) {
 		jobSpec.Spec.Template.Labels = map[string]string{}
 	}
 	jobSpec.Spec.Template.Labels[SelectorLabel] = b.labelID()
-	propagationPolicy := metav1.DeletePropagationOrphan
 
 	return &Job{
-		Job:               jobSpec,
-		jobClient:         jobClient,
-		podClient:         podClient,
-		restClient:        restClient,
-		config:            b.config,
-		propagationPolicy: &propagationPolicy,
+		Job:        jobSpec,
+		jobClient:  jobClient,
+		podClient:  podClient,
+		restClient: restClient,
+		config:     b.config,
 	}, nil
 }

--- a/job.go
+++ b/job.go
@@ -122,11 +122,8 @@ func (j *Job) DisableCommandLog() {
 	j.disabledCommandLog = true
 }
 
-func (j *Job) EnableJobDeletion() {
-	j.enableJobDeletion = true
-}
-
 func (j *Job) SetDeletePropagationPolicy(propagation metav1.DeletionPropagation) {
+	j.enableJobDeletion = true
 	j.propagationPolicy = &propagation
 }
 

--- a/job.go
+++ b/job.go
@@ -128,10 +128,10 @@ func (j *Job) SetDeletePropagationPolicy(propagation metav1.DeletionPropagation)
 }
 
 func (j *Job) cleanup(ctx context.Context) error {
+	j.logDebug("cleanup job %s", j.Name)
 	if !j.enableJobDeletion {
 		return nil
 	}
-	j.logDebug("cleanup job %s", j.Name)
 	if err := j.jobClient.Delete(ctx, j.Name, metav1.DeleteOptions{
 		GracePeriodSeconds: new(int64), // assign zero value as GracePeriodSeconds to delete immediately.
 		PropagationPolicy:  j.propagationPolicy,
@@ -520,7 +520,7 @@ func (j *Job) logStreamContainer(ctx context.Context, pod *corev1.Pod, container
 		j.containerLogs <- j.commandLog(pod, container)
 	}
 
-	errchan := make(chan error, 1)
+	errchan := make(chan error)
 
 	go func() {
 		reader := bufio.NewReader(stream)


### PR DESCRIPTION
## Breaking Changes

Kubernetes update has changed the behavior around job deletion. In accordance with this change, we will unify the deletion with the original behavior of Kubernetes Job.

As before, if a kubejob is forced to delete a Job, it should call the `SetDeletePropagationPolicy` API .

