### PR TITLE
Fix finalizer container's termination

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -492,6 +492,9 @@ func (j *Job) runWithExecutionHandler(ctx context.Context, cancelFn func(), hand
 					if err := finalizer.Handler(finalizerExecutor); err != nil {
 						j.logWarn("failed to finalize: %s", err)
 					}
+					if err := finalizerExecutor.Stop(); err != nil {
+						j.logWarn("failed to stop finalizer: %w", err)
+					}
 				} else {
 					if _, err := finalizerExecutor.Exec(); err != nil {
 						j.logWarn("failed to finalize: %s", err)

--- a/job_test.go
+++ b/job_test.go
@@ -673,7 +673,7 @@ func Test_RunnerWithSideCar(t *testing.T) {
 				Command: []string{"echo", "finalizer"},
 			},
 			Handler: func(exec *kubejob.JobExecutor) error {
-				out, err := exec.Exec()
+				out, err := exec.ExecOnly()
 				if err != nil {
 					t.Fatalf("%s: %+v", string(out), err)
 				}


### PR DESCRIPTION
If ExecOnly is called in the handler, finalizer container cannot be terminated without explicitly calling Stop.