### PR TITLE
Safely terminate a Job on cancel

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,9 +1,11 @@
 package kubejob
 
+import "context"
+
 func (e *JobExecutor) ExecWithPodNotFoundError() ([]byte, error) {
 	name := e.Pod.Name
 	e.Pod.Name = "invalid-pod-name"
-	out, err := e.Exec()
+	out, err := e.Exec(context.Background())
 	e.Pod.Name = name
 	e.Stop()
 	return out, err

--- a/job.go
+++ b/job.go
@@ -187,17 +187,7 @@ func (j *Job) Run(ctx context.Context) (e error) {
 		}
 	}()
 
-	errCh := make(chan error)
-	go func() {
-		errCh <- j.wait(ctx)
-	}()
-	select {
-	case <-ctx.Done():
-		return nil
-	case err := <-errCh:
-		return err
-	}
-	return nil
+	return j.wait(ctx)
 }
 
 func (j *Job) containerLog(log *ContainerLog) {
@@ -353,7 +343,7 @@ func (j *Job) watchLoop(ctx context.Context, watcher watch.Interface) (e error) 
 				})
 			})
 			if j.preInit.needsToRun(pod.Status) {
-				if err := j.preInit.run(pod); err != nil {
+				if err := j.preInit.run(ctx, pod); err != nil {
 					return err
 				}
 			}
@@ -361,7 +351,7 @@ func (j *Job) watchLoop(ctx context.Context, watcher watch.Interface) (e error) 
 				if j.preInit != nil && !j.preInit.done {
 					continue
 				}
-				if err := j.jobInit.run(pod); err != nil {
+				if err := j.jobInit.run(ctx, pod); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
- Propagate context to all executors
- Add original command / args to env at `RunWithExecutionHandlers`